### PR TITLE
removing quotes so parsing doesn't fail

### DIFF
--- a/nginx-bridge.json
+++ b/nginx-bridge.json
@@ -10,9 +10,9 @@
     }
   },
   "id": "nginx",
-  "instances": "1",
-  "cpus": "0.25",
-  "mem": "256",
+  "instances": 1,
+  "cpus": 0.25,
+  "mem": 256,
   "uris": []
 }
 

--- a/redis-constraint.json
+++ b/redis-constraint.json
@@ -8,9 +8,9 @@
     }    
   },
   "id": "redis",
-  "instances": "1",
-  "cpus": "0.25",
-  "mem": "256",
+  "instances": 1,
+  "cpus": 0.25,
+  "mem": 256,
   "uris": [],
   "constraints": [["rack", "CLUSTER", "rack-2"]]
 }

--- a/redis-unique.json
+++ b/redis-unique.json
@@ -6,9 +6,9 @@
     }    
   },
   "id": "redis",
-  "instances": "1",
-  "cpus": "0.25",
-  "mem": "256",
+  "instances": 1,
+  "cpus": 0.25,
+  "mem": 256,
   "uris": [],
   "constraints": [["hostname", "UNIQUE"]]
 }

--- a/redis.json
+++ b/redis.json
@@ -6,8 +6,8 @@
     }    
   },
   "id": "redis",
-  "instances": "1",
-  "cpus": "0.25",
-  "mem": "256",
+  "instances": 1,
+  "cpus": 0.25,
+  "mem": 256,
   "uris": []
 }

--- a/simple-docker.json
+++ b/simple-docker.json
@@ -6,9 +6,9 @@
     }    
   },
   "id": "ubuntu",
-  "instances": "1",
-  "cpus": "0.25",
-  "mem": "256",
+  "instances": 1,
+  "cpus": 0.25,
+  "mem": 256,
   "uris": [],
   "cmd": "while sleep 10; do date -u +%T; done"
 }


### PR DESCRIPTION
Currently most of the examples are putting quotes around their numbers which is causing them to fail since the system is expecting numbers not strings
